### PR TITLE
Skip DISCONNECT events

### DIFF
--- a/unifi_protect_backup/unifi_protect_backup.py
+++ b/unifi_protect_backup/unifi_protect_backup.py
@@ -425,6 +425,8 @@ class UnifiProtectBackup:
             return
         if msg.new_obj.end is None:
             return
+        if msg.new_obj.type not in [EventType.MOTION, EventType.SMART_DETECT, EventType.RING]:
+            return
         if msg.new_obj.type is EventType.MOTION and "motion" not in self.detection_types:
             logger.extra_debug(f"Skipping unwanted motion detection event: {msg.new_obj.id}")  # type: ignore
             return


### PR DESCRIPTION
DISCONNECT events never have video associated with them, skip processing if we encounter one. This fixes #31 which prevents unnecessary fetch attempts.