### PR TITLE
Change Purge's execution interval from 60s to 1d

### DIFF
--- a/unifi_protect_backup/purge.py
+++ b/unifi_protect_backup/purge.py
@@ -32,7 +32,7 @@ async def tidy_empty_dirs(base_dir_path):
 class Purge:
     """Deletes old files from rclone remotes"""
 
-    def __init__(self, db: aiosqlite.Connection, retention: relativedelta, rclone_destination: str, interval: int = 60):
+    def __init__(self, db: aiosqlite.Connection, retention: relativedelta, rclone_destination: str, interval: int = 86400):
         self._db: aiosqlite.Connection = db
         self.retention: relativedelta = retention
         self.rclone_destination: str = rclone_destination


### PR DESCRIPTION
It was apparently intended to run purge 'every midnight', i.e. once per day. However the sleep interval after each purge was set to 60 seconds. This commit changes it to 1 day (86,400 seconds) as a quick fix.

See https://github.com/ep1cman/unifi-protect-backup/blob/ca455ebcd0350f58a6f331931fc810648d3ac697/unifi_protect_backup/unifi_protect_backup.py#L203