### PR TITLE
Build for arm/v7, add makefile target, adjust Github Action.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: ghcr.io/${{ github.repository }}:${{ steps.tag_name.outputs.current_version }}, ghcr.io/${{ github.repository }}:latest
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 # To build run:
-# $ poetry build
-# $ docker build -t ghcr.io/ep1cman/unifi-protect-backup .
+# make docker
 
 FROM ghcr.io/linuxserver/baseimage-alpine:3.16
 

--- a/makefile
+++ b/makefile
@@ -1,4 +1,6 @@
 sources = unifi_protect_backup
+container_name ?= ghcr.io/ep1cman/unifi-protect-backup
+container_arches ?= linux/amd64,linux/arm64,linux/arm/v7
 
 .PHONY: test format lint unittest coverage pre-commit clean
 test: format lint unittest
@@ -25,3 +27,7 @@ clean:
 	rm -rf *.egg-info
 	rm -rf .tox dist site
 	rm -rf coverage.xml .coverage
+
+docker:
+	poetry build
+	docker buildx build . --platform $(container_arches) -t $(container_name) --push


### PR DESCRIPTION
Wanted to try this on my Pi - realized the Docker image wasn't compatible so adjusted this so it was.

I have pushed it here to at least make sure it builds:

https://hub.docker.com/repository/docker/darron/unifi-protect-backup

Haven't tested it yet - hoping to try it out later this week.

The makefile variables are set that way so that it's much easier to adjust Docker repos, build arches with environment variables.

Thought I'd contribute - but no worries if it's not wanted.