### PR TITLE
Fixed the docker run command example which

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ docker run \
   -e UFP_SSL_VERIFY='false' \
   -e RCLONE_DESTINATION='my_remote:/unifi_protect_backup' \
   -v '/path/to/save/clips':'/data' \
-  -v `/path/to/rclone.conf':'/config/rclone/rclone.conf' \
+  -v '/path/to/rclone.conf':'/config/rclone/rclone.conf' \
   -v '/path/to/save/database':/config/database/ \
   ghcr.io/ep1cman/unifi-protect-backup
 ```


### PR DESCRIPTION
Fixed the docker run command example which had a ` instead of a '. This caused the command to never terminate when executing.