### PR TITLE
Update unifi_protect_backup_core.py

### DIFF
--- a/unifi_protect_backup/unifi_protect_backup_core.py
+++ b/unifi_protect_backup/unifi_protect_backup_core.py
@@ -181,7 +181,7 @@ class UnifiProtectBackup:
             # Start the pyunifiprotect connection by calling `update`
             logger.info("Connecting to Unifi Protect...")
 
-            for attempts in range(1):
+            for attempts in range(10):
                 try:
                     await self._protect.update()
                     break


### PR DESCRIPTION
Fix typo in connection attempts.  The application only attempts to connect once instead of 10 times.  Incidentally the newest version of Unifi Protect is not fully compatible with pyunifiprotect causing an exception to be thrown on the first attempt, but not the second.  This also will allow the application to continue working with the newest version of Unifi Protect while we wait for pyunifiprotect to be updated.