### PR TITLE
Update docs for ignoring cameras

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,8 @@ If you use this feature it is advised that your run the tool once with this flag
 
 Cameras can be excluded from backups by either:
 - Using `--ignore-camera`, see [usage](#usage)
-  - IDs can be obtained by scanning the logs: `docker logs {container_id} 2>&1 | sed -n '/Found cameras:/,/NVR TZ/p'`
+  - IDs can be obtained by scanning the logs, starting at `Found cameras:` up to the next log line (currently `NVR TZ`). You can find this section of the logs by piping the logs in to this `sed` command
+    `sed -n '/Found cameras:/,/NVR TZ/p'`
 - Using a Unifi user with a role which has access retricted to the subset of cameras that you wish to backup.
 
 # A note about `rclone` backends and disk wear

--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ Options:
   --ignore-camera TEXT            IDs of cameras for which events should not be backed up. Use
                                   multiple times to ignore multiple IDs. If being set as an
                                   environment variable the IDs should be separated by whitespace.
+                                  Alternatively, use a Unifi user with a role which has access
+                                  retricted to the subset of cameras that you wish to backup.
   --file-structure-format TEXT    A Python format string used to generate the file structure/name
                                   on the rclone remote.For details of the fields available, see
                                   the projects `README.md` file.  [default: {camera_name}/{event.s
@@ -241,6 +243,13 @@ If you prefer to avoid backing up the entire backlog of events, and would instea
 now on, you can use the `--skip-missing` flag. This does not enable the periodic check for missing event (e.g. one that was missed by a disconnection) but instead marks all missing events at start-up as backed up.
 
 If you use this feature it is advised that your run the tool once with this flag, then stop it once the database has been created and the events are ignored. Keeping this flag set permanently could cause events to be missed if the tool crashes and is restarted etc.
+
+## Ignoring cameras
+
+Cameras can be excluded from backups by either:
+- Using `--ignore-camera`, see [usage](#usage)
+  - IDs can be obtained by scanning the logs: `docker logs {container_id} 2>&1 | sed -n '/Found cameras:/,/NVR TZ/p'`
+- Using a Unifi user with a role which has access retricted to the subset of cameras that you wish to backup.
 
 # A note about `rclone` backends and disk wear
 This tool attempts to not write the downloaded files to disk to minimise disk wear, and instead streams them directly to 


### PR DESCRIPTION
First off, thanks for this amazing tool. This fixes my main gripe with Unifi cameras - no offsite backups :slightly_smiling_face: 

Some context: I wanted to use the `--ignore-camera` option to exclude a couple of indoor cameras that I have, and it took me a few minutes to find the IDs in the logs, so I thought it would be useful to document how to parse these.

I did have a look at adding a command to dump the camera IDs, however, I then realized that you can just use a Unifi user with a role restricted to only a subset of cameras to achieve the same thing. To be honest, I can't see why you wouldn't go this route rather than block-listing clientside, but I guess it's nice to have the option. This option wasn't immediately obvious to me, so I wanted to document it for others benefit.