### PR TITLE
Fix iterating over empty events

### DIFF
--- a/unifi_protect_backup/missing_event_checker.py
+++ b/unifi_protect_backup/missing_event_checker.py
@@ -80,6 +80,9 @@ class MissingEventChecker:
             # Filter out on-going events
             unifi_events = {event.id: event for event in events_chunk if event.end is not None}
 
+            if not unifi_events:
+                break  # No completed events to process
+
             # Next chunks start time should be the end of the oldest complete event in the current chunk
             start_time = max([event.end for event in unifi_events.values()])
 


### PR DESCRIPTION
Fixes occasional error:

```
sender-1    |   File "/usr/lib/python3.12/site-packages/unifi_protect_backup/missing_event_checker.py", line 166, in start
sender-1    |     async for event in self._get_missing_events():
sender-1    |   File "/usr/lib/python3.12/site-packages/unifi_protect_backup/missing_event_checker.py", line 87, in _get_missing_events
sender-1    |     start_time = max([event.end for event in unifi_events.values()])
sender-1    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
sender-1    | ValueError: max() iterable argument is empty
```

... It seems to be trying to iterate over events. It did check for no events in `events_chunk`, but if `events_chunk` contained events but all of them were ongoing, it would throw.