### PR TITLE
Added documentation on how to run the docker container similar to a service with restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,11 +139,6 @@ Options:
                                   environment variable the IDs should be separated by whitespace.
                                   Alternatively, use a Unifi user with a role which has access
                                   restricted to the subset of cameras that you wish to backup.
-   --camera TEXT                   IDs of *ONLY* cameras for which events should be backed up. Use
-                                  multiple times to include multiple IDs. If being set as an
-                                  environment variable the IDs should be separated by whitespace.
-                                  Alternatively, use a Unifi user with a role which has access
-                                  restricted to the subset of cameras that you wish to backup.
   --file-structure-format TEXT    A Python format string used to generate the file structure/name
                                   on the rclone remote.For details of the fields available, see
                                   the projects `README.md` file.  [default: {camera_name}/{event.s
@@ -218,7 +213,6 @@ always take priority over environment variables):
 - `RCLONE_ARGS`
 - `RCLONE_PURGE_ARGS`
 - `IGNORE_CAMERAS`
-- `CAMERAS`
 - `DETECTION_TYPES`
 - `FILE_STRUCTURE_FORMAT`
 - `SQLITE_PATH`
@@ -254,45 +248,13 @@ now on, you can use the `--skip-missing` flag. This does not enable the periodic
 
 If you use this feature it is advised that your run the tool once with this flag, then stop it once the database has been created and the events are ignored. Keeping this flag set permanently could cause events to be missed if the tool crashes and is restarted etc.
 
-## Selecting cameras
+## Ignoring cameras
 
-By default unifi-protect-backup backs up clips from all cameras.
-If you want to limit the backups to certain cameras you can do that in one of two ways.
-
-Note: Camera IDs can be obtained by scanning the logs, by looking for `Found cameras:`. You can find this section of the logs by piping the logs in to this `sed` command
+Cameras can be excluded from backups by either:
+- Using `--ignore-camera`, see [usage](#usage)
+  - IDs can be obtained by scanning the logs, starting at `Found cameras:` up to the next log line (currently `NVR TZ`). You can find this section of the logs by piping the logs in to this `sed` command
     `sed -n '/Found cameras:/,/NVR TZ/p'`
-
-### Back-up only specific cameras
-By using the `--camera` argument, you can specify the ID of the cameras you want to backup. If you want to backup more than one camera you can specify this argument more than once. If this argument is specified all other cameras will be ignored.
-
-#### Example:
-If you have three cameras:
-  - `CAMERA_ID_1`
-  - `CAMERA_ID_2`
-  - `CAMERA_ID_3`
-and run the following command:
-```
-$ unifi-protect-backup [...] --camera CAMERA_ID_1 --camera CAMERA_ID_2
-```
-Only `CAMERA_ID_1` and `CAMERA_ID_2` will be backed up.
-
-### Ignoring cameras
-
-By using the `--ignore-camera` argument, you can specify the ID of the cameras you *do not* want to backup. If you want to ignore more than one camera you can specify this argument more than once. If this argument is specified all cameras will be backed up except the ones specified
-
-#### Example:
-If you have three cameras:
-  - `CAMERA_ID_1`
-  - `CAMERA_ID_2`
-  - `CAMERA_ID_3`
-and run the following command:
-```
-$ unifi-protect-backup [...] --ignore-camera CAMERA_ID_1 --ignore-camera CAMERA_ID_2
-```
-Only `CAMERA_ID_3` will be backed up.
-
-### Note about unifi protect accounts
-It is possible to limit what cameras a unifi protect accounts can see. If an account does not have access to a camera this tool will never see it as available so it will not be impacted by the above arguments.
+- Using a Unifi user with a role which has access restricted to the subset of cameras that you wish to backup.
 
 # A note about `rclone` backends and disk wear
 This tool attempts to not write the downloaded files to disk to minimise disk wear, and instead streams them directly to 
@@ -359,6 +321,19 @@ To check the status of the service use this command.
 
 ```
 sudo systemctl status protectbackup.service --no-pager
+```
+
+# Running Backup Tool as a Service (Docker ONLY)
+If you are using Docker you can pass the flag to start the container automatically after a power cycle / reboot. The `restart` argument can be passed with the `unless-stopped` or `always` argument. See the Docker documentation, [Start containers automatically](https://docs.docker.com/engine/containers/start-containers-automatically/), for more information. This can be done in any environment, not just in Linux. If this is used then *do not* also configure this as a service as described in section "Running Backup Tool as a Service (LINUX ONLY)"
+
+## Example
+```
+docker run \
+  -e UFP_USERNAME='USERNAME' \
+  -e UFP_PASSWORD='PASSWORD' \
+  # ... other flags and arguments ...
+  --restart unless-stopped
+  ghcr.io/ep1cman/unifi-protect-backup
 ```
 
 # Debugging


### PR DESCRIPTION
Added documentation on how to run the docker container similar to a service with the `restart` flag. This is much easier to configure over a Linux service and is also applicable to other O/S's.

If you want, I can also add a section + code for docker compose using the default arguments that were provided elsewhere in the documentation. Let me know and I can amend the PR with that and resubmit.