### PR TITLE
Fix cp command always running

### DIFF
--- a/docker_root/etc/cont-init.d/30-config
+++ b/docker_root/etc/cont-init.d/30-config
@@ -4,7 +4,7 @@ mkdir -p /config/rclone
 
 # For backwards compatibility
 [[ -f "/root/.config/rclone/rclone.conf" ]] && \
-    echo "DEPRECATED: Copying rclone conf from /root/.config/rclone/rclone.conf, please change your mount to /config/rclone/rclone.conf"
+    echo "DEPRECATED: Copying rclone conf from /root/.config/rclone/rclone.conf, please change your mount to /config/rclone/rclone.conf" && \
     cp \
         /root/.config/rclone/rclone.conf \
         /config/rclone/rclone.conf


### PR DESCRIPTION
The CP command always runs even if the file `/root/.config/rclone/rclone.conf` doesn't exist.