### PR TITLE
Move log to after delete finished

### DIFF
--- a/unifi_protect_backup/purge.py
+++ b/unifi_protect_backup/purge.py
@@ -70,8 +70,8 @@ class Purge:
                         # For every backup for this event
                         async with self._db.execute(f"SELECT * FROM backups WHERE id = '{event_id}'") as backup_cursor:
                             async for _, remote, file_path in backup_cursor:
-                                logger.debug(f" Deleted: {remote}:{file_path}")
                                 await delete_file(f"{remote}:{file_path}", self.rclone_purge_args)
+                                logger.debug(f" Deleted: {remote}:{file_path}")
                                 deleted_a_file = True
 
                         # delete event from database


### PR DESCRIPTION
The log happens before the delete file command has finished running. This makes it look like the delete is instant even though it takes some time. Moving the log after makes it a little clearer how much time it is taking in the logs.