### PR TITLE
Fix skipping overlapping events on chunk boundary

### DIFF
--- a/unifi_protect_backup/missing_event_checker.py
+++ b/unifi_protect_backup/missing_event_checker.py
@@ -83,8 +83,8 @@ class MissingEventChecker:
             if not unifi_events:
                 break  # No completed events to process
 
-            # Next chunks start time should be the end of the oldest complete event in the current chunk
-            start_time = max([event.end for event in unifi_events.values() if event.end is not None])
+            # Next chunks start time should be the start of the oldest complete event in the current chunk
+            start_time = max([event.start for event in unifi_events.values() if event.end is not None])
 
             # Get list of events that have been backed up from the database
 


### PR DESCRIPTION
I don't know if this is correct as i don't know how i would test this but i think some events might be missed.

E.g.
If the 500th event has a start time of 12:13 and end time of 12:30 and the 501st event has a start time of 12:15 and end time of 12:20, wouldn't the 501st event be skipped as we change the next start time to be 12:30 which is the max end time?

The way it is set up in this PR, the 500th event will show up twice. I have tested this and confirmed the next batch has the same earliest event as the last batches latest event. This should not be an issue though as it is filtered out if it already exists in the download queue.