### PR TITLE
Stop missing event checker from checking entire range every time

### DIFF
--- a/unifi_protect_backup/__init__.py
+++ b/unifi_protect_backup/__init__.py
@@ -4,20 +4,20 @@ __author__ = """sebastian.goscik"""
 __email__ = "sebastian@goscik.com"
 __version__ = "0.14.0"
 
+from .missing_event_data import MissingEventData
 from .downloader import VideoDownloader
 from .downloader_experimental import VideoDownloaderExperimental
 from .event_listener import EventListener
 from .purge import Purge
-from .missing_event_data import MissingEventData
 from .uploader import VideoUploader
 from .missing_event_checker import MissingEventChecker
 
 __all__ = [
+    "MissingEventData",
     "VideoDownloader",
     "VideoDownloaderExperimental",
     "EventListener",
     "Purge",
-    "MissingEventData",
     "VideoUploader",
     "MissingEventChecker",
 ]

--- a/unifi_protect_backup/__init__.py
+++ b/unifi_protect_backup/__init__.py
@@ -8,6 +8,7 @@ from .downloader import VideoDownloader
 from .downloader_experimental import VideoDownloaderExperimental
 from .event_listener import EventListener
 from .purge import Purge
+from .missing_event_data import MissingEventData
 from .uploader import VideoUploader
 from .missing_event_checker import MissingEventChecker
 
@@ -16,6 +17,7 @@ __all__ = [
     "VideoDownloaderExperimental",
     "EventListener",
     "Purge",
+    "MissingEventData",
     "VideoUploader",
     "MissingEventChecker",
 ]

--- a/unifi_protect_backup/downloader.py
+++ b/unifi_protect_backup/downloader.py
@@ -58,6 +58,7 @@ class VideoDownloader:
 
         Args:
             protect (ProtectApiClient): UniFi Protect API client to use
+            missing_data (MissingEventData): Additional data used for missing event checker
             db (aiosqlite.Connection): Async SQLite database to check for missing events
             download_queue (asyncio.Queue): Queue to get event details from
             upload_queue (VideoQueue): Queue to place downloaded videos on
@@ -191,8 +192,8 @@ class VideoDownloader:
                 assert isinstance(video, bytes)
                 break
             except (AssertionError, ClientPayloadError, TimeoutError) as e:
-                self.logger.warning(f"    Failed download attempt {x + 1}, retying in {2 ** x}s", exc_info=e)
-                await asyncio.sleep(2 ** x)
+                self.logger.warning(f"    Failed download attempt {x + 1}, retying in {2**x}s", exc_info=e)
+                await asyncio.sleep(2**x)
         else:
             self.logger.error(f"Download failed after 5 attempts, abandoning event {event.id}:")
             return None

--- a/unifi_protect_backup/downloader_experimental.py
+++ b/unifi_protect_backup/downloader_experimental.py
@@ -58,6 +58,7 @@ class VideoDownloaderExperimental:
 
         Args:
             protect (ProtectApiClient): UniFi Protect API client to use
+            missing_data (MissingEventData): Additional data used for missing event checker
             db (aiosqlite.Connection): Async SQLite database to check for missing events
             download_queue (asyncio.Queue): Queue to get event details from
             upload_queue (VideoQueue): Queue to place downloaded videos on
@@ -202,8 +203,8 @@ class VideoDownloaderExperimental:
                 assert isinstance(video, bytes)
                 break
             except (AssertionError, ClientPayloadError, TimeoutError) as e:
-                self.logger.warning(f"    Failed download attempt {x + 1}, retying in {2 ** x}s", exc_info=e)
-                await asyncio.sleep(2 ** x)
+                self.logger.warning(f"    Failed download attempt {x + 1}, retying in {2**x}s", exc_info=e)
+                await asyncio.sleep(2**x)
         else:
             self.logger.error(f"Download failed after 5 attempts, abandoning event {event.id}:")
             return None

--- a/unifi_protect_backup/downloader_experimental.py
+++ b/unifi_protect_backup/downloader_experimental.py
@@ -16,6 +16,7 @@ from uiprotect import ProtectApiClient
 from uiprotect.data.nvr import Event
 from uiprotect.data.types import EventType
 
+from unifi_protect_backup import MissingEventData
 from unifi_protect_backup.utils import (
     SubprocessException,
     VideoQueue,
@@ -45,6 +46,7 @@ class VideoDownloaderExperimental:
     def __init__(
         self,
         protect: ProtectApiClient,
+        missing_data: MissingEventData,
         db: aiosqlite.Connection,
         download_queue: asyncio.Queue,
         upload_queue: VideoQueue,
@@ -66,6 +68,7 @@ class VideoDownloaderExperimental:
         """
         self._protect: ProtectApiClient = protect
         self._db: aiosqlite.Connection = db
+        self._missing_data: MissingEventData = missing_data
         self.download_queue: asyncio.Queue = download_queue
         self.upload_queue: VideoQueue = upload_queue
         self.current_event = None
@@ -160,6 +163,8 @@ class VideoDownloaderExperimental:
                             "Event has failed to download 10 times in a row. Permanently ignoring this event"
                         )
                         await self._ignore_event(event)
+                    else:
+                        self._missing_data.update_start_time(event.start)
                     continue
 
                 # Remove successfully downloaded event from failures list
@@ -197,8 +202,8 @@ class VideoDownloaderExperimental:
                 assert isinstance(video, bytes)
                 break
             except (AssertionError, ClientPayloadError, TimeoutError) as e:
-                self.logger.warning(f"    Failed download attempt {x + 1}, retying in 1s", exc_info=e)
-                await asyncio.sleep(1)
+                self.logger.warning(f"    Failed download attempt {x + 1}, retying in {2 ** x}s", exc_info=e)
+                await asyncio.sleep(2 ** x)
         else:
             self.logger.error(f"Download failed after 5 attempts, abandoning event {event.id}:")
             return None

--- a/unifi_protect_backup/missing_event_checker.py
+++ b/unifi_protect_backup/missing_event_checker.py
@@ -68,7 +68,7 @@ class MissingEventChecker:
 
         while True:
             # Get list of events that need to be backed up from unifi protect
-            logger.debug_extra(f"Fetching events for interval: {start_time} - {end_time}")  # type: ignore
+            logger.extra_debug(f"Fetching events for interval: {start_time} - {end_time}")  # type: ignore
             events_chunk = await self._protect.get_events(
                 start=start_time,
                 end=end_time,

--- a/unifi_protect_backup/missing_event_checker.py
+++ b/unifi_protect_backup/missing_event_checker.py
@@ -150,6 +150,8 @@ class MissingEventChecker:
         """Run main loop."""
         logger.info("Starting Missing Event Checker")
         while True:
+            start_time = self._missing_data.get_start_time()
+
             try:
                 shown_warning = False
 
@@ -180,5 +182,7 @@ class MissingEventChecker:
                     "Unexpected exception occurred during missing event check:",
                     exc_info=e,
                 )
+                # Set start time back to earlier time if missing event check failed
+                self._missing_data.update_start_time(start_time)
 
             await asyncio.sleep(self.interval)

--- a/unifi_protect_backup/missing_event_data.py
+++ b/unifi_protect_backup/missing_event_data.py
@@ -26,7 +26,7 @@ class MissingEventData:
 
         """
         if start_time < self.start_time:
-            logger.debug_extra(  # type: ignore
+            logger.extra_debug(  # type: ignore
                 f"Making next missing events checker earlier: '{start_time.strftime('%Y-%m-%dT%H-%M-%S')}'"
             )
             self.start_time = start_time

--- a/unifi_protect_backup/missing_event_data.py
+++ b/unifi_protect_backup/missing_event_data.py
@@ -1,0 +1,45 @@
+# noqa: D100
+
+import logging
+from datetime import datetime
+
+logger = logging.getLogger(__name__)
+
+
+class MissingEventData:
+    """Stores data used for MissingEventChecker."""
+
+    def __init__(self, start_time: datetime) -> None:
+        """Init.
+
+        Args:
+            start_time (datetime): Time to start first missing events checker with
+
+        """
+        self.start_time: datetime = start_time
+
+    def update_start_time(self, start_time: datetime):
+        """Update the start time if it is earlier than the last start time.
+
+        Args:
+            start_time (datetime): New start time
+
+        """
+        if start_time < self.start_time:
+            logger.debug_extra(  # type: ignore
+                f"Making next missing events checker earlier: '{start_time.strftime('%Y-%m-%dT%H-%M-%S')}'"
+            )
+            self.start_time = start_time
+
+    def get_start_time(self) -> datetime:
+        """Get the start time."""
+        return self.start_time
+
+    def set_start_time(self, start_time: datetime):
+        """Set the start time to a new datetime.
+
+        Args:
+            start_time (datetime): New start time
+
+        """
+        self.start_time = start_time

--- a/unifi_protect_backup/unifi_protect_backup_core.py
+++ b/unifi_protect_backup/unifi_protect_backup_core.py
@@ -275,8 +275,13 @@ class UnifiProtectBackup:
             else:
                 downloader_cls = VideoDownloader
 
+            missing_data = MissingEventData(
+                datetime.now(timezone.utc) - self.missing_range,
+            )
+
             downloader = downloader_cls(
                 self._protect,
+                missing_data,
                 self._db,
                 download_queue,
                 upload_queue,
@@ -285,10 +290,6 @@ class UnifiProtectBackup:
                 self._max_event_length,
             )
             tasks.append(downloader.start())
-
-            missing_data = MissingEventData(
-                datetime.now(timezone.utc) - self.missing_range,
-            )
 
             # Create upload tasks
             #   This will upload the videos in the downloader's buffer to the rclone remotes and log it in the database

--- a/unifi_protect_backup/uploader.py
+++ b/unifi_protect_backup/uploader.py
@@ -27,6 +27,7 @@ class VideoUploader:
 
     def __init__(
         self,
+        core,
         protect: ProtectApiClient,
         upload_queue: VideoQueue,
         rclone_destination: str,
@@ -47,6 +48,7 @@ class VideoUploader:
             color_logging (bool):  Whether or not to add color to logging output
 
         """
+        self._core = core
         self._protect: ProtectApiClient = protect
         self.upload_queue: VideoQueue = upload_queue
         self._rclone_destination: str = rclone_destination
@@ -88,6 +90,7 @@ class VideoUploader:
                     self.logger.debug("Uploaded")
                 except SubprocessException:
                     self.logger.error(f" Failed to upload file: '{destination}'")
+                    self._core.missing.update_start_time(event.start)
 
                 self.current_event = None
 

--- a/unifi_protect_backup/uploader.py
+++ b/unifi_protect_backup/uploader.py
@@ -9,6 +9,7 @@ import aiosqlite
 from uiprotect import ProtectApiClient
 from uiprotect.data.nvr import Event
 
+from unifi_protect_backup import MissingEventData
 from unifi_protect_backup.utils import (
     SubprocessException,
     VideoQueue,
@@ -27,8 +28,8 @@ class VideoUploader:
 
     def __init__(
         self,
-        core,
         protect: ProtectApiClient,
+        missing_data: MissingEventData,
         upload_queue: VideoQueue,
         rclone_destination: str,
         rclone_args: str,
@@ -40,6 +41,7 @@ class VideoUploader:
 
         Args:
             protect (ProtectApiClient): UniFi Protect API client to use
+            missing_data (MissingEventData): Additional data used for missing event checker
             upload_queue (VideoQueue): Queue to get video files from
             rclone_destination (str): rclone file destination URI
             rclone_args (str): arguments to pass to the rclone command
@@ -48,8 +50,8 @@ class VideoUploader:
             color_logging (bool):  Whether or not to add color to logging output
 
         """
-        self._core = core
         self._protect: ProtectApiClient = protect
+        self._missing_data: MissingEventData = missing_data
         self.upload_queue: VideoQueue = upload_queue
         self._rclone_destination: str = rclone_destination
         self._rclone_args: str = rclone_args
@@ -90,7 +92,7 @@ class VideoUploader:
                     self.logger.debug("Uploaded")
                 except SubprocessException:
                     self.logger.error(f" Failed to upload file: '{destination}'")
-                    self._core.missing.update_start_time(event.start)
+                    self._missing_data.update_start_time(event.start)
 
                 self.current_event = None
 


### PR DESCRIPTION
Reduce the time range used for missing events checker to stop checking the entire range every time.
Once the missing events checker starts, the start of of the next time range will be the end of the current time range. This can be made earlier for reasons such as ongoing events and failed uploads.

I have tested failing uploads by throwing an error and checking to see if the start time has gone earlier for the next missing events checker.
I haven't tested ongoing events as it is hard to time an active event to trigger when the missing events checker is running.