### PR TITLE
Fix slow missing events check

### DIFF
--- a/unifi_protect_backup/missing_event_checker.py
+++ b/unifi_protect_backup/missing_event_checker.py
@@ -105,10 +105,11 @@ class MissingEventChecker:
                 if current_upload is not None:
                     uploading_event_ids.add(current_upload.id)
 
+            existing_ids = db_event_ids | downloading_event_ids | uploading_event_ids
             missing_events = {
                 event_id: event
                 for event_id, event in unifi_events.items()
-                if event_id not in (db_event_ids | downloading_event_ids | uploading_event_ids)
+                if event_id not in existing_ids
             }
 
             # Exclude events of unwanted types


### PR DESCRIPTION
The purge events were taking 24 seconds to complete for each event. This is strange due to the actual purge command taking around 2 seconds.

The issue is due to the missing events loop taking 23 seconds to complete. The next purge event can't start while this is still active. Moving the sets combination from the if statement to outside the loop reduces this to 0.05 seconds which allows purge events to run on time.

This also reduces the total runtime for the missing events checker on my Raspberry Pi from 55 mins to 2 mins and 36 seconds.