### PR TITLE
Fix timezone double-conversion causing ~10h sleep in downloader (#248)

### DIFF
--- a/unifi_protect_backup/downloader.py
+++ b/unifi_protect_backup/downloader.py
@@ -105,10 +105,18 @@ class VideoDownloader:
                 self.current_event = event
                 self.logger = logging.LoggerAdapter(self.base_logger, {"event": f" [{event.id}]"})
 
-                # Fix timezones since uiprotect sets all timestamps to UTC. Instead localize them to
-                # the timezone of the unifi protect NVR.
-                event.start = event.start.replace(tzinfo=pytz.utc).astimezone(self._protect.bootstrap.nvr.timezone)
-                event.end = event.end.replace(tzinfo=pytz.utc).astimezone(self._protect.bootstrap.nvr.timezone)
+                # Normalize event timestamps to NVR local time. uiprotect historically returned
+                # naive UTC datetimes, but newer versions may return timezone-aware datetimes
+                # already in local time. Guard against double-converting (issue #248).
+                nvr_tz = self._protect.bootstrap.nvr.timezone
+                if event.start.tzinfo is None:
+                    event.start = event.start.replace(tzinfo=pytz.utc).astimezone(nvr_tz)
+                else:
+                    event.start = event.start.astimezone(nvr_tz)
+                if event.end.tzinfo is None:
+                    event.end = event.end.replace(tzinfo=pytz.utc).astimezone(nvr_tz)
+                else:
+                    event.end = event.end.astimezone(nvr_tz)
 
                 self.logger.info(f"Downloading event: {event.id}")
                 self.logger.debug(f"Remaining Download Queue: {self.download_queue.qsize()}")
@@ -139,6 +147,7 @@ class VideoDownloader:
                 # but often longer)
                 time_since_event_ended = datetime.utcnow().replace(tzinfo=timezone.utc) - event.end
                 sleep_time = (timedelta(seconds=5 * 1.5) - time_since_event_ended).total_seconds()
+                sleep_time = min(sleep_time, 60)  # cap: a bad timestamp should never stall the queue
                 if sleep_time > 0:
                     self.logger.debug(f"  Sleeping ({sleep_time}s) to ensure clip is ready to download...")
                     await asyncio.sleep(sleep_time)

--- a/unifi_protect_backup/downloader_experimental.py
+++ b/unifi_protect_backup/downloader_experimental.py
@@ -103,10 +103,18 @@ class VideoDownloaderExperimental:
                 self.current_event = event
                 self.logger = logging.LoggerAdapter(self.base_logger, {"event": f" [{event.id}]"})
 
-                # Fix timezones since uiprotect sets all timestamps to UTC. Instead localize them to
-                # the timezone of the unifi protect NVR.
-                event.start = event.start.replace(tzinfo=pytz.utc).astimezone(self._protect.bootstrap.nvr.timezone)
-                event.end = event.end.replace(tzinfo=pytz.utc).astimezone(self._protect.bootstrap.nvr.timezone)
+                # Normalize event timestamps to NVR local time. uiprotect historically returned
+                # naive UTC datetimes, but newer versions may return timezone-aware datetimes
+                # already in local time. Guard against double-converting (issue #248).
+                nvr_tz = self._protect.bootstrap.nvr.timezone
+                if event.start.tzinfo is None:
+                    event.start = event.start.replace(tzinfo=pytz.utc).astimezone(nvr_tz)
+                else:
+                    event.start = event.start.astimezone(nvr_tz)
+                if event.end.tzinfo is None:
+                    event.end = event.end.replace(tzinfo=pytz.utc).astimezone(nvr_tz)
+                else:
+                    event.end = event.end.astimezone(nvr_tz)
 
                 self.logger.info(f"Downloading event: {event.id}")
                 self.logger.debug(f"Remaining Download Queue: {self.download_queue.qsize()}")
@@ -137,6 +145,7 @@ class VideoDownloaderExperimental:
                 # but often longer)
                 time_since_event_ended = datetime.utcnow().replace(tzinfo=timezone.utc) - event.end
                 sleep_time = (timedelta(seconds=5 * 1.5) - time_since_event_ended).total_seconds()
+                sleep_time = min(sleep_time, 60)  # cap: a bad timestamp should never stall the queue
                 if sleep_time > 0:
                     self.logger.debug(f"  Sleeping ({sleep_time}s) to ensure clip is ready to download...")
                     await asyncio.sleep(sleep_time)


### PR DESCRIPTION
## Summary

- `downloader.py` and `downloader_experimental.py` both unconditionally stamped event timestamps as UTC via `.replace(tzinfo=pytz.utc)`, then converted to NVR local time. Newer versions of `uiprotect` may return timezone-aware datetimes already in local time, causing a double-conversion that pushes `event.end` forward by the NVR's UTC offset.
- This made `sleep_time` ~36,000 seconds (10h for UTC+10), completely stalling the download queue for the rest of the container's uptime.
- Added a `tzinfo` guard to both downloaders: naive datetimes get the existing UTC→local conversion; aware datetimes are simply converted to NVR tz with `.astimezone()`.
- Added a 60s cap on `sleep_time` in both downloaders as a safety net against future timestamp anomalies.

Fixes #248.

## Test plan

- [ ] Verify events with naive UTC timestamps (existing behaviour) still download correctly
- [ ] Verify events with timezone-aware timestamps (new uiprotect behaviour) no longer cause an excessive sleep
- [ ] Confirm `sleep_time` never exceeds 60s regardless of timestamp content
- [ ] Verify the same behaviour with `--experimental-downloader` flag