### PR TITLE
Only queue an event when it actually finishes

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,7 @@
 """Shared test setup.
 
-The package logs at custom levels (``extra_debug``, ``websocket_data``) that
-``setup_logging`` installs at startup. These tests exercise modules directly rather than
-going through the CLI, so the levels have to be registered here or any logging call
-raises AttributeError.
+These tests exercise modules directly rather than through the CLI, so the custom log
+levels ``setup_logging`` normally installs have to be registered here.
 """
 
 import logging

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+"""Shared test setup.
+
+The package logs at custom levels (``extra_debug``, ``websocket_data``) that
+``setup_logging`` installs at startup. These tests exercise modules directly rather than
+going through the CLI, so the levels have to be registered here or any logging call
+raises AttributeError.
+"""
+
+import logging
+
+from unifi_protect_backup.utils import add_logging_level
+
+for _name, _level in (("EXTRA_DEBUG", logging.DEBUG - 1), ("WEBSOCKET_DATA", logging.DEBUG - 2)):
+    if not hasattr(logging, _name):
+        add_logging_level(_name, _level)

--- a/tests/test_event_listener.py
+++ b/tests/test_event_listener.py
@@ -1,0 +1,185 @@
+"""Tests for the websocket event listener's queuing decisions.
+
+The listener is where duplicate backups were being created. Protect sends several update
+messages per event, and the old guard (`"end" in msg.changed_data`) fired on all of them
+because `changed_data` is the raw payload rather than a diff. Each extra queue entry cost
+a full NVR download and an upload that overwrote the object already in the remote.
+
+These tests are synchronous because `_websocket_callback` is a synchronous callback that
+runs on the event loop thread.
+"""
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from uiprotect.data.nvr import Event
+from uiprotect.data.types import EventType
+from uiprotect.data.websocket import WSAction, WSSubscriptionMessage
+
+from unifi_protect_backup.event_listener import EventListener
+
+START = datetime(2026, 9, 1, 12, 0, 0, tzinfo=timezone.utc)
+END = START + timedelta(seconds=30)
+CAMERA = "67cb31f301131a03e401cf0e"
+
+# Both formats are live: Protect moved motion/smartDetect to UUIDs in March 2026 but
+# smartAudioDetect and ring still use 24-char MongoDB ObjectIds.
+UUID_ID = "f9f5a34b-867d-4001-9b42-c3429c1785df"
+OBJECT_ID = "6a9871de000cec03e42f4991"
+
+
+def make_event(event_id=UUID_ID, end=END, event_type=EventType.MOTION, camera_id=CAMERA):
+    """Build an Event without running validation, which needs the full Protect payload."""
+    return Event.model_construct(
+        id=event_id,
+        type=event_type,
+        camera_id=camera_id,
+        start=START,
+        end=end,
+        smart_detect_types=[],
+    )
+
+
+def make_msg(new_obj, old_obj=None, action=WSAction.UPDATE):
+    """Build a websocket message.
+
+    `changed_data` is deliberately given the full payload shape, matching what uiprotect
+    actually produces, to make sure nothing depends on it being a diff.
+    """
+    return WSSubscriptionMessage(
+        action=action,
+        new_update_id="update-1",
+        changed_data={"end": new_obj.end, "type": "motion", "camera_id": new_obj.camera_id},
+        new_obj=new_obj,
+        old_obj=old_obj,
+    )
+
+
+@pytest.fixture
+def listener():
+    """Build a listener writing into an unbounded queue, matching production wiring."""
+    return EventListener(
+        event_queue=asyncio.Queue(),
+        protect=None,
+        detection_types={"motion", "person", "alrmSpeak"},
+        ignore_cameras=set(),
+        cameras=set(),
+    )
+
+
+def queued_ids(listener):
+    """Return the IDs currently sitting on the download queue."""
+    return [e.id for e in listener._event_queue._queue]
+
+
+def test_completed_event_is_queued(listener):
+    """The normal case: end appears for the first time."""
+    listener._websocket_callback(make_msg(make_event(), old_obj=make_event(end=None)))
+    assert queued_ids(listener) == [UUID_ID]
+
+
+def test_repeated_identical_end_is_not_queued(listener):
+    """The bug. Protect repeats an unchanged `end`; only the first should queue.
+
+    Both messages carry `end` in changed_data, which is exactly why the old guard fired
+    twice and produced two uploads to the same key.
+    """
+    listener._websocket_callback(make_msg(make_event(), old_obj=make_event(end=None)))
+    listener._websocket_callback(make_msg(make_event(), old_obj=make_event()))
+    assert queued_ids(listener) == [UUID_ID]
+
+
+def test_three_repeats_queue_once(listener):
+    """20% of duplicates in production were triples, not pairs."""
+    listener._websocket_callback(make_msg(make_event(), old_obj=make_event(end=None)))
+    for _ in range(2):
+        listener._websocket_callback(make_msg(make_event(), old_obj=make_event()))
+    assert queued_ids(listener) == [UUID_ID]
+
+
+def test_ongoing_event_is_not_queued(listener):
+    """An event with no end has not finished."""
+    listener._websocket_callback(make_msg(make_event(end=None), old_obj=make_event(end=None)))
+    assert queued_ids(listener) == []
+
+
+def test_non_update_action_is_ignored(listener):
+    """Only UPDATE messages can mark an event finished."""
+    listener._websocket_callback(make_msg(make_event(), action=WSAction.ADD))
+    assert queued_ids(listener) == []
+
+
+def test_changed_end_is_queued_once_then_suppressed(listener):
+    """An extended event is backed up once, at its first observed end.
+
+    The comparison lets a genuinely changed `end` through, but the ID cache then drops it.
+    That is deliberate. Backing it up twice would write a second file under a second name
+    whose `events` row insert fails on the primary key, leaving a file that `Purge` can
+    never delete.
+    """
+    listener._websocket_callback(make_msg(make_event(), old_obj=make_event(end=None)))
+    listener._websocket_callback(make_msg(make_event(end=END + timedelta(seconds=30)), old_obj=make_event()))
+    assert queued_ids(listener) == [UUID_ID]
+
+
+def test_missing_old_obj_falls_through_to_the_cache(listener):
+    """With nothing to compare against, queue it rather than risk losing footage.
+
+    Dropping a real event costs footage; queuing a duplicate costs money. The cache stops
+    the second one, so falling through is the safe direction.
+    """
+    listener._websocket_callback(make_msg(make_event(), old_obj=None))
+    listener._websocket_callback(make_msg(make_event(), old_obj=None))
+    assert queued_ids(listener) == [UUID_ID]
+
+
+def test_unwanted_detection_type_is_not_queued(listener):
+    """Detection types the user did not ask for are dropped."""
+    listener._websocket_callback(make_msg(make_event(event_type=EventType.RING), old_obj=make_event(end=None)))
+    assert queued_ids(listener) == []
+
+
+def test_ignored_camera_is_not_queued():
+    """Cameras on the ignore list are dropped."""
+    listener = EventListener(asyncio.Queue(), None, {"motion"}, {CAMERA}, set())
+    listener._websocket_callback(make_msg(make_event(), old_obj=make_event(end=None)))
+    assert queued_ids(listener) == []
+
+
+def test_object_id_format_dedups(listener):
+    """Audio and ring events still use 24-char ObjectIds, about 31% of events."""
+    audio = dict(event_id=OBJECT_ID, event_type=EventType.SMART_AUDIO_DETECT)
+    first = make_event(**audio)
+    first.smart_detect_types = ["alrmSpeak"]
+    second = make_event(**audio)
+    second.smart_detect_types = ["alrmSpeak"]
+
+    listener._websocket_callback(make_msg(first, old_obj=make_event(end=None, **audio)))
+    listener._websocket_callback(make_msg(second, old_obj=make_event(**audio)))
+    assert queued_ids(listener) == [OBJECT_ID]
+
+
+def test_appended_camera_suffix_normalizes_to_one_entry(listener):
+    """The websocket can append a camera ID; both forms are the same event."""
+    listener._websocket_callback(make_msg(make_event(event_id=f"{UUID_ID}-{CAMERA}"), old_obj=make_event(end=None)))
+    listener._websocket_callback(make_msg(make_event(event_id=UUID_ID), old_obj=make_event()))
+    assert queued_ids(listener) == [UUID_ID]
+
+
+def test_queued_event_is_a_copy(listener):
+    """A later message must not be able to mutate an event already in the queue.
+
+    `msg.new_obj` is uiprotect's cached instance. It mutates in place when the next
+    message for that event arrives, and the downloader has by then rewritten `end` into
+    NVR-local time. Sharing the object let a later UTC value leak back in, which filed
+    16,348 clips four hours off.
+    """
+    source = make_event()
+    listener._websocket_callback(make_msg(source, old_obj=make_event(end=None)))
+
+    queued = listener._event_queue._queue[0]
+    assert queued is not source
+
+    source.end = datetime(2000, 1, 1, tzinfo=timezone.utc)
+    assert queued.end == END

--- a/tests/test_event_listener.py
+++ b/tests/test_event_listener.py
@@ -1,13 +1,4 @@
-"""Tests for the websocket event listener's queuing decisions.
-
-The listener is where duplicate backups were being created. Protect sends several update
-messages per event, and the old guard (`"end" in msg.changed_data`) fired on all of them
-because `changed_data` is the raw payload rather than a diff. Each extra queue entry cost
-a full NVR download and an upload that overwrote the object already in the remote.
-
-These tests are synchronous because `_websocket_callback` is a synchronous callback that
-runs on the event loop thread.
-"""
+"""Tests for the websocket event listener's queuing decisions."""
 
 import asyncio
 from datetime import datetime, timedelta, timezone
@@ -23,8 +14,7 @@ START = datetime(2026, 9, 1, 12, 0, 0, tzinfo=timezone.utc)
 END = START + timedelta(seconds=30)
 CAMERA = "67cb31f301131a03e401cf0e"
 
-# Both formats are live: Protect moved motion/smartDetect to UUIDs in March 2026 but
-# smartAudioDetect and ring still use 24-char MongoDB ObjectIds.
+# Protect uses UUIDs for motion/smartDetect and 24-char ObjectIds for smartAudioDetect/ring.
 UUID_ID = "f9f5a34b-867d-4001-9b42-c3429c1785df"
 OBJECT_ID = "6a9871de000cec03e42f4991"
 
@@ -42,11 +32,7 @@ def make_event(event_id=UUID_ID, end=END, event_type=EventType.MOTION, camera_id
 
 
 def make_msg(new_obj, old_obj=None, action=WSAction.UPDATE):
-    """Build a websocket message.
-
-    `changed_data` is deliberately given the full payload shape, matching what uiprotect
-    actually produces, to make sure nothing depends on it being a diff.
-    """
+    """Build a websocket message, with `changed_data` shaped as uiprotect produces it."""
     return WSSubscriptionMessage(
         action=action,
         new_update_id="update-1",
@@ -58,7 +44,7 @@ def make_msg(new_obj, old_obj=None, action=WSAction.UPDATE):
 
 @pytest.fixture
 def listener():
-    """Build a listener writing into an unbounded queue, matching production wiring."""
+    """Build a listener writing into an unbounded queue."""
     return EventListener(
         event_queue=asyncio.Queue(),
         protect=None,
@@ -80,18 +66,14 @@ def test_completed_event_is_queued(listener):
 
 
 def test_repeated_identical_end_is_not_queued(listener):
-    """The bug. Protect repeats an unchanged `end`; only the first should queue.
-
-    Both messages carry `end` in changed_data, which is exactly why the old guard fired
-    twice and produced two uploads to the same key.
-    """
+    """Protect repeats an unchanged `end`; only the first message should queue."""
     listener._websocket_callback(make_msg(make_event(), old_obj=make_event(end=None)))
     listener._websocket_callback(make_msg(make_event(), old_obj=make_event()))
     assert queued_ids(listener) == [UUID_ID]
 
 
 def test_three_repeats_queue_once(listener):
-    """20% of duplicates in production were triples, not pairs."""
+    """Protect often sends three updates, not two."""
     listener._websocket_callback(make_msg(make_event(), old_obj=make_event(end=None)))
     for _ in range(2):
         listener._websocket_callback(make_msg(make_event(), old_obj=make_event()))
@@ -111,12 +93,10 @@ def test_non_update_action_is_ignored(listener):
 
 
 def test_changed_end_is_queued_once_then_suppressed(listener):
-    """An extended event is backed up once, at its first observed end.
+    """A changed `end` passes the comparison but is then dropped by the ID cache.
 
-    The comparison lets a genuinely changed `end` through, but the ID cache then drops it.
-    That is deliberate. Backing it up twice would write a second file under a second name
-    whose `events` row insert fails on the primary key, leaving a file that `Purge` can
-    never delete.
+    Backing the event up twice would leave a second file whose `events` row insert fails
+    on the primary key, so `Purge` could never delete it.
     """
     listener._websocket_callback(make_msg(make_event(), old_obj=make_event(end=None)))
     listener._websocket_callback(make_msg(make_event(end=END + timedelta(seconds=30)), old_obj=make_event()))
@@ -124,11 +104,7 @@ def test_changed_end_is_queued_once_then_suppressed(listener):
 
 
 def test_missing_old_obj_falls_through_to_the_cache(listener):
-    """With nothing to compare against, queue it rather than risk losing footage.
-
-    Dropping a real event costs footage; queuing a duplicate costs money. The cache stops
-    the second one, so falling through is the safe direction.
-    """
+    """With nothing to compare against, queue it and let the cache stop the repeat."""
     listener._websocket_callback(make_msg(make_event(), old_obj=None))
     listener._websocket_callback(make_msg(make_event(), old_obj=None))
     assert queued_ids(listener) == [UUID_ID]
@@ -148,7 +124,7 @@ def test_ignored_camera_is_not_queued():
 
 
 def test_object_id_format_dedups(listener):
-    """Audio and ring events still use 24-char ObjectIds, about 31% of events."""
+    """Audio and ring events use 24-char ObjectIds rather than UUIDs."""
     audio = dict(event_id=OBJECT_ID, event_type=EventType.SMART_AUDIO_DETECT)
     first = make_event(**audio)
     first.smart_detect_types = ["alrmSpeak"]
@@ -170,10 +146,8 @@ def test_appended_camera_suffix_normalizes_to_one_entry(listener):
 def test_queued_event_is_a_copy(listener):
     """A later message must not be able to mutate an event already in the queue.
 
-    `msg.new_obj` is uiprotect's cached instance. It mutates in place when the next
-    message for that event arrives, and the downloader has by then rewritten `end` into
-    NVR-local time. Sharing the object let a later UTC value leak back in, which filed
-    16,348 clips four hours off.
+    `new_obj` is uiprotect's cached instance and mutates in place, which would put a UTC
+    `end` back onto an event the downloader had already localised to NVR time.
     """
     source = make_event()
     listener._websocket_callback(make_msg(source, old_obj=make_event(end=None)))

--- a/unifi_protect_backup/event_listener.py
+++ b/unifi_protect_backup/event_listener.py
@@ -2,9 +2,9 @@
 
 import asyncio
 import logging
-from time import sleep
 from typing import Set
 
+from expiring_dict import ExpiringDict  # type: ignore
 from uiprotect.api import ProtectApiClient
 from uiprotect.websocket import WebsocketState
 from uiprotect.data.nvr import Event
@@ -13,6 +13,9 @@ from uiprotect.data.websocket import WSAction, WSSubscriptionMessage
 from unifi_protect_backup.utils import normalize_event_id, wanted_event_type
 
 logger = logging.getLogger(__name__)
+
+# How long an event ID stays in the "already queued" set, in seconds.
+QUEUED_EVENT_TTL = 15 * 60
 
 
 class EventListener:
@@ -44,6 +47,12 @@ class EventListener:
         self.ignore_cameras: Set[str] = ignore_cameras
         self.cameras: Set[str] = cameras
 
+        # IDs queued recently, to drop repeated websocket messages for one event.
+        # Nothing legitimately re-queues the same ID from here: a backup that fails is
+        # recovered by the missing event checker, not by a websocket replay. So the
+        # window only needs to outlast Protect's own repeats.
+        self._recently_queued = ExpiringDict(QUEUED_EVENT_TTL)
+
     async def start(self):
         """Run main Loop."""
         logger.debug("Subscribed to websocket")
@@ -62,24 +71,48 @@ class EventListener:
         logger.websocket_data(msg)  # type: ignore
 
         assert isinstance(msg.new_obj, Event)
+        new_obj = msg.new_obj
+
         if msg.action != WSAction.UPDATE:
             return
-        if "end" not in msg.changed_data:
-            return
-        if not wanted_event_type(msg.new_obj, self.detection_types, self.cameras, self.ignore_cameras):
-            return
 
-        # TODO: Will this even work? I think it will block the async loop
-        while self._event_queue.full():
-            logger.extra_debug("Event queue full, waiting 1s...")  # type: ignore
-            sleep(1)
+        # An event we can back up is one that just finished. `changed_data` cannot tell us
+        # that: uiprotect fills it with the raw payload Protect sent, key-renamed, without
+        # ever comparing against the previous state (see `Bootstrap._process_device_update`).
+        # Testing `"end" in changed_data` therefore only means "Protect mentioned end",
+        # which it does on every update for an event, so a single event was being queued
+        # two or three times. Compare the old and new objects instead.
+        if new_obj.end is None:
+            return  # Still on-going
+        if isinstance(msg.old_obj, Event) and msg.old_obj.end == new_obj.end:
+            return  # Protect repeating itself, nothing new completed
+
+        if not wanted_event_type(new_obj, self.detection_types, self.cameras, self.ignore_cameras):
+            return
 
         # Normalize the event ID so it matches what the API returns
-        msg.new_obj.id = normalize_event_id(msg.new_obj.id)
+        event_id = normalize_event_id(new_obj.id)
 
-        self._event_queue.put_nowait(msg.new_obj)
+        # Backstop for anything the comparison above misses, e.g. an update we cannot
+        # compare because `old_obj` was absent. Cheap insurance on the one path that
+        # spends money: every event queued twice is a second NVR download and a second
+        # upload that overwrites the object already in the remote.
+        if event_id in self._recently_queued:
+            logger.extra_debug(f"Ignoring repeated websocket event {event_id}")  # type: ignore
+            return
+        self._recently_queued[event_id] = True
 
-        logger.debug(f"Adding event {msg.new_obj.id} to queue (Current download queue={self._event_queue.qsize()})")
+        # Queue a copy, never the object itself. `msg.new_obj` is the instance uiprotect
+        # keeps in its bootstrap cache and mutates in place on the next message for this
+        # event. The downloader localises `event.end` to the NVR timezone, so a later
+        # message writing a fresh UTC value back onto a still-queued object makes the
+        # uploader build the filename from the wrong timezone.
+        event = new_obj.model_copy()
+        event.id = event_id
+
+        self._event_queue.put_nowait(event)
+
+        logger.debug(f"Adding event {event.id} to queue (Current download queue={self._event_queue.qsize()})")
 
     def _websocket_state_callback(self, state: WebsocketState) -> None:
         """Websocket state message callback.

--- a/unifi_protect_backup/event_listener.py
+++ b/unifi_protect_backup/event_listener.py
@@ -74,12 +74,12 @@ class EventListener:
         if msg.action != WSAction.UPDATE:
             return
 
-        # `changed_data` is the payload Protect sent, not a diff, so it carries `end` on
-        # every update once an event has finished. Compare old and new objects instead.
+        # `changed_data` is Protect's payload, not a diff: a finished event carries `end`
+        # in every later update, so only the old/new comparison finds where it finished.
         if new_obj.end is None:
             return  # Still on-going
         if isinstance(msg.old_obj, Event) and msg.old_obj.end == new_obj.end:
-            return  # Protect repeating itself, nothing new completed
+            return  # Same end time, nothing new has finished
 
         if not wanted_event_type(new_obj, self.detection_types, self.cameras, self.ignore_cameras):
             return
@@ -93,8 +93,8 @@ class EventListener:
             return
         self._recently_queued[event_id] = True
 
-        # Queue a copy. `new_obj` is uiprotect's cached instance, mutated in place by later
-        # messages, which would undo the NVR timezone the downloader localises `end` to.
+        # Queue a copy: `new_obj` is uiprotect's cached instance and later messages mutate
+        # it in place, overwriting the NVR-local `end` the downloader sets.
         event = new_obj.model_copy()
         event.id = event_id
 

--- a/unifi_protect_backup/event_listener.py
+++ b/unifi_protect_backup/event_listener.py
@@ -14,7 +14,7 @@ from unifi_protect_backup.utils import normalize_event_id, wanted_event_type
 
 logger = logging.getLogger(__name__)
 
-# How long an event ID stays in the "already queued" set, in seconds.
+# How long an event ID is remembered as already queued, in seconds.
 QUEUED_EVENT_TTL = 15 * 60
 
 
@@ -47,10 +47,8 @@ class EventListener:
         self.ignore_cameras: Set[str] = ignore_cameras
         self.cameras: Set[str] = cameras
 
-        # IDs queued recently, to drop repeated websocket messages for one event.
-        # Nothing legitimately re-queues the same ID from here: a backup that fails is
-        # recovered by the missing event checker, not by a websocket replay. So the
-        # window only needs to outlast Protect's own repeats.
+        # Recently queued IDs, to drop repeated websocket messages for the same event.
+        # Failed backups are retried by the missing event checker, not by re-queuing here.
         self._recently_queued = ExpiringDict(QUEUED_EVENT_TTL)
 
     async def start(self):
@@ -76,12 +74,8 @@ class EventListener:
         if msg.action != WSAction.UPDATE:
             return
 
-        # An event we can back up is one that just finished. `changed_data` cannot tell us
-        # that: uiprotect fills it with the raw payload Protect sent, key-renamed, without
-        # ever comparing against the previous state (see `Bootstrap._process_device_update`).
-        # Testing `"end" in changed_data` therefore only means "Protect mentioned end",
-        # which it does on every update for an event, so a single event was being queued
-        # two or three times. Compare the old and new objects instead.
+        # `changed_data` is the payload Protect sent, not a diff, so it carries `end` on
+        # every update once an event has finished. Compare old and new objects instead.
         if new_obj.end is None:
             return  # Still on-going
         if isinstance(msg.old_obj, Event) and msg.old_obj.end == new_obj.end:
@@ -93,20 +87,14 @@ class EventListener:
         # Normalize the event ID so it matches what the API returns
         event_id = normalize_event_id(new_obj.id)
 
-        # Backstop for anything the comparison above misses, e.g. an update we cannot
-        # compare because `old_obj` was absent. Cheap insurance on the one path that
-        # spends money: every event queued twice is a second NVR download and a second
-        # upload that overwrites the object already in the remote.
+        # Backstop for updates the comparison cannot catch, e.g. when `old_obj` is missing
         if event_id in self._recently_queued:
             logger.extra_debug(f"Ignoring repeated websocket event {event_id}")  # type: ignore
             return
         self._recently_queued[event_id] = True
 
-        # Queue a copy, never the object itself. `msg.new_obj` is the instance uiprotect
-        # keeps in its bootstrap cache and mutates in place on the next message for this
-        # event. The downloader localises `event.end` to the NVR timezone, so a later
-        # message writing a fresh UTC value back onto a still-queued object makes the
-        # uploader build the filename from the wrong timezone.
+        # Queue a copy. `new_obj` is uiprotect's cached instance, mutated in place by later
+        # messages, which would undo the NVR timezone the downloader localises `end` to.
         event = new_obj.model_copy()
         event.id = event_id
 


### PR DESCRIPTION
Fixes #252.

Every event that finishes gets added to the download queue 2 or 3 times, so every clip gets pulled from the NVR and uploaded 2 or 3 times. It's easy to miss because all the copies write to the same path and just overwrite each other.

The listener decides an event has finished by checking whether the websocket message mentioned an end time:

```python
if "end" not in msg.changed_data:
    return
```

`changed_data` isn't a diff of what changed though, it's the payload Protect sent with the keys renamed. Once an event has an end time Protect includes it in every update it sends for that event, so this matches 2 or 3 messages per event instead of one.

This compares the end time before and after the update instead. `old_obj` and `new_obj` are the same event one message apart, so if the end time hasn't changed, this isn't the message where the event finished. There's also a short lived set of recently queued ids as a backstop.

The second change is queuing a copy of the event rather than the object itself. uiprotect keeps that object in its bootstrap cache and mutates it in place when the next message for the event arrives, so an event still sitting in the queue could have its end time rewritten before the downloader picked it up. The downloader converts the end time to the NVR timezone, so that would leave you with a file named in the wrong timezone.

12 tests in `tests/test_event_listener.py`, covering the repeated end time, the triples, an event that hasn't finished yet, and the copy. `conftest.py` just registers the custom log levels, otherwise the listener's logging calls fail when the tests run outside the CLI.

20 minutes against my NVR, same events on both sides:

```
main     100 queue lines, 45 distinct events, 45 queued more than once
patched   45 queue lines, 45 distinct events,  0 queued more than once
```
