### PR TITLE
Clear current_event on every downloader exit path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,11 @@ dev = [
     "pre-commit>=4.2.0",
     "ruff>=0.11.4",
     "pytest>=8.3.5",
+    "pytest-asyncio>=0.24.0",
 ]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
 
 [tool.hatch.build.targets.wheel]
 packages = ["unifi_protect_backup"]

--- a/tests/test_failed_download_recovery.py
+++ b/tests/test_failed_download_recovery.py
@@ -1,0 +1,177 @@
+"""Tests that the missing event checker can still recover a failed download.
+
+The checker skips whatever `current_event` points at, so the downloader and the checker
+are exercised together. Both downloader classes are covered; they share the same loop.
+"""
+
+import asyncio
+import logging
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytz
+from dateutil.relativedelta import relativedelta
+from uiprotect.data.nvr import Event
+from uiprotect.data.types import EventType
+
+from unifi_protect_backup.downloader import VideoDownloader
+from unifi_protect_backup.downloader_experimental import VideoDownloaderExperimental
+from unifi_protect_backup.missing_event_checker import MissingEventChecker
+from unifi_protect_backup.unifi_protect_backup_core import create_database
+from unifi_protect_backup.utils import VideoQueue, add_logging_level
+
+# The checker logs at a custom level that `setup_logging` normally installs.
+if not hasattr(logging, "EXTRA_DEBUG"):
+    add_logging_level("EXTRA_DEBUG", logging.DEBUG - 1)
+
+CAMERA = "67cb31f301131a03e401cf0e"
+FAILED_ID = "e7c1b7d0-0d4a-4b31-9d1e-9f0f0a1b2c3d"
+
+
+class _Camera:
+    name = "Front Door"
+
+
+class _NVR:
+    timezone = pytz.utc
+
+
+class _Bootstrap:
+    def __init__(self):
+        """Init."""
+        self.nvr = _NVR()
+        self.cameras = {CAMERA: _Camera()}
+
+
+class _Protect:
+    """Stub Protect API for both the downloader and the checker."""
+
+    def __init__(self, events):
+        """Init."""
+        self.bootstrap = _Bootstrap()
+        self.connect_event = asyncio.Event()
+        self.connect_event.set()
+        self._events = events
+        self.calls = 0
+
+    async def get_events(self, **kwargs):
+        """Return the chunk once, then report exhaustion."""
+        self.calls += 1
+        return self._events if self.calls == 1 else []
+
+
+class _SignallingQueue(asyncio.Queue):
+    """Download queue that reports when the downloader asks for the next event.
+
+    The downloader only asks again once the previous iteration has unwound, so the
+    second `get()` marks the end of that iteration.
+    """
+
+    def __init__(self):
+        """Init."""
+        super().__init__()
+        self.iteration_finished = asyncio.Event()
+        self._gets = 0
+
+    async def get(self):
+        """Record the call, then hand over an event as usual."""
+        self._gets += 1
+        if self._gets == 2:
+            self.iteration_finished.set()
+        return await super().get()
+
+
+def make_event(event_id: str) -> Event:
+    """Build a completed motion event, ended long enough ago to be downloadable."""
+    end = datetime.now(timezone.utc) - timedelta(minutes=5)
+    return Event.model_construct(
+        id=event_id,
+        type=EventType.MOTION,
+        camera_id=CAMERA,
+        start=end - timedelta(seconds=10),
+        end=end,
+        smart_detect_types=[],
+    )
+
+
+def make_downloader(downloader_class, db, protect, download_queue):
+    """Build a real downloader whose downloads come back empty, failing `assert video is not None`."""
+    downloader = downloader_class(
+        protect=protect,
+        db=db,
+        download_queue=download_queue,
+        upload_queue=VideoQueue(1024),
+        color_logging=False,
+        download_rate_limit=None,
+        max_event_length=timedelta(minutes=5),
+    )
+
+    async def _no_video(event):
+        return None
+
+    downloader._download = _no_video
+    return downloader
+
+
+def make_checker(db, protect, downloader) -> MissingEventChecker:
+    """Build a real checker watching the given downloader."""
+    return MissingEventChecker(
+        protect=protect,
+        db=db,
+        download_queue=downloader.download_queue,
+        downloader=downloader,
+        uploaders=[],
+        retention=relativedelta(days=7),
+        detection_types={"motion"},
+        ignore_cameras=set(),
+        cameras=set(),
+    )
+
+
+@pytest.fixture
+async def event_db():
+    """Build an in-memory database using the real production schema."""
+    connection = await create_database(":memory:")
+    yield connection
+    await connection.close()
+
+
+@pytest.fixture(params=[VideoDownloader, VideoDownloaderExperimental], ids=["standard", "experimental"])
+async def failed_download(request, event_db):
+    """Run one downloader iteration whose download fails, then yield it with a checker."""
+    event = make_event(FAILED_ID)
+    protect = _Protect([event])
+    download_queue = _SignallingQueue()
+    downloader = make_downloader(request.param, event_db, protect, download_queue)
+
+    download_queue.put_nowait(event)
+    task = asyncio.create_task(downloader.start())
+    try:
+        await asyncio.wait_for(download_queue.iteration_finished.wait(), timeout=5)
+        yield downloader, make_checker(event_db, protect, downloader)
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+async def test_failed_download_is_offered_again_by_the_checker(failed_download):
+    """Nothing else retries it, so it has to come back."""
+    _, checker = failed_download
+
+    missing = [event.id async for event in checker._get_missing_events()]
+
+    assert missing == [FAILED_ID]
+
+
+async def test_failed_download_leaves_no_database_row(failed_download, event_db):
+    """One failure is not enough to ignore the event, so the checker is its only route back."""
+    async with event_db.execute("SELECT id FROM events") as cursor:
+        assert await cursor.fetchall() == []
+
+
+async def test_failed_download_clears_current_event(failed_download):
+    """The attribute the checker reads to decide an event is in flight."""
+    downloader, _ = failed_download
+
+    assert downloader.current_event is None

--- a/unifi_protect_backup/downloader.py
+++ b/unifi_protect_backup/downloader.py
@@ -171,10 +171,13 @@ class VideoDownloader:
 
                 await self.upload_queue.put((event, video))
                 self.logger.debug("Added to upload queue")
-                self.current_event = None
 
             except Exception as e:
                 self.logger.error(f"Unexpected exception occurred, abandoning event {event.id}:", exc_info=e)
+            finally:
+                # The missing event checker skips whatever this holds, so a failed
+                # download that left it set would never be retried.
+                self.current_event = None
 
     async def _download(self, event: Event) -> Optional[bytes]:
         """Download the video clip for the given event."""

--- a/unifi_protect_backup/downloader_experimental.py
+++ b/unifi_protect_backup/downloader_experimental.py
@@ -172,13 +172,16 @@ class VideoDownloaderExperimental:
 
                 await self.upload_queue.put((event, video))
                 self.logger.debug("Added to upload queue")
-                self.current_event = None
 
             except Exception as e:
                 self.logger.error(
                     f"Unexpected exception occurred, abandoning event {event.id}:",
                     exc_info=e,
                 )
+            finally:
+                # The missing event checker skips whatever this holds, so a failed
+                # download that left it set would never be retried.
+                self.current_event = None
 
     async def _download(self, event: Event) -> Optional[bytes]:
         """Download the video clip for the given event."""

--- a/uv.lock
+++ b/uv.lock
@@ -1110,6 +1110,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -1454,6 +1467,7 @@ dev = [
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
     { name = "types-aiofiles" },
     { name = "types-cryptography" },
@@ -1481,6 +1495,7 @@ dev = [
     { name = "mypy", specifier = ">=1.15.0" },
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "pytest", specifier = ">=8.3.5" },
+    { name = "pytest-asyncio", specifier = ">=0.24.0" },
     { name = "ruff", specifier = ">=0.11.4" },
     { name = "types-aiofiles", specifier = ">=24.1.0.20241221" },
     { name = "types-cryptography", specifier = ">=3.3.18" },


### PR DESCRIPTION
If a download fails the event can end up never being retried. It sits there unbacked-up until the downloader happens to pick up some other event, which on a quiet camera can be hours.

The downloader records what it is working on when it takes an event off the queue:

```python
self.current_event = event
```

and clears it only after the download succeeds:

```python
await self.upload_queue.put((event, video))
self.logger.debug("Added to upload queue")
self.current_event = None
```

A failed download takes the `continue` above that line:

```python
except Exception as e:
    ...
    if self._failures[event.id] >= 10:
        await self._ignore_event(event)
    continue
```

so `current_event` is still pointing at the event that just failed.

The missing event checker treats whatever `current_event` holds as a download in progress and excludes it:

```python
current_download = self._downloader.current_event
if current_download is not None:
    downloading_event_ids.add(current_download.id)

existing_ids = db_event_ids | downloading_event_ids | uploading_event_ids
```

By then the event is off the download queue and has no row in `events`, since one failure isn't enough for `_ignore_event`. So the checker is the only thing that can bring it back, and it's the one thing being told to skip it. It stays skipped until the downloader dequeues something else and overwrites the attribute.

The fix is a `finally` on the loop body so every exit clears it, not just the success path.

The test runs the real downloader and the real checker together, since the attribute doesn't mean anything without the code that reads it. With a failed download the checker reports nothing missing on current main, and reports the failed event with this change. Both downloader classes are covered because they have the same loop.

One thing worth mentioning is how this interacts with #253. Before that, the listener queued each event two or three times, so a failed download usually still had a copy in the queue, and picking that up overwrote `current_event` and retried the event as a side effect. With one queue entry per event the checker is the only route back, so this matters more than it did.

The second commit adds pytest-asyncio. The download loop can't be driven without an event loop so there was no way to test this otherwise, but if you'd rather not take the dependency I can rework the test to run the loop itself.
