### PR TITLE
Catch IntegrityError when the experimental downloader ignores an event

### DIFF
--- a/tests/test_ignore_event.py
+++ b/tests/test_ignore_event.py
@@ -1,0 +1,67 @@
+"""Tests that ignoring an event which is already recorded is not an error.
+
+The same event can reach the downloader from both the websocket and the missing event
+checker, so it can already be in the database by the time it gets ignored. Both
+downloader classes have to survive that.
+"""
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from uiprotect.data.nvr import Event
+from uiprotect.data.types import EventType
+
+from unifi_protect_backup.downloader import VideoDownloader
+from unifi_protect_backup.downloader_experimental import VideoDownloaderExperimental
+from unifi_protect_backup.unifi_protect_backup_core import create_database
+from unifi_protect_backup.utils import VideoQueue
+
+CAMERA = "67cb31f301131a03e401cf0e"
+EVENT_ID = "f9f5a34b-867d-4001-9b42-c3429c1785df"
+
+
+def make_event() -> Event:
+    """Build a completed motion event."""
+    start = datetime(2026, 9, 1, 12, 0, 0, tzinfo=timezone.utc)
+    return Event.model_construct(
+        id=EVENT_ID,
+        type=EventType.MOTION,
+        camera_id=CAMERA,
+        start=start,
+        end=start + timedelta(seconds=10),
+        smart_detect_types=[],
+    )
+
+
+async def ignore_twice(downloader_class):
+    """Ignore one event twice, then return the ids left in the events table."""
+    db = await create_database(":memory:")
+    try:
+        downloader = downloader_class(
+            protect=None,
+            db=db,
+            download_queue=asyncio.Queue(),
+            upload_queue=VideoQueue(1024),
+            color_logging=False,
+            download_rate_limit=None,
+            max_event_length=timedelta(minutes=5),
+        )
+        event = make_event()
+        await downloader._ignore_event(event)
+        await downloader._ignore_event(event)
+
+        async with db.execute("SELECT id FROM events") as cursor:
+            return [row[0] for row in await cursor.fetchall()]
+    finally:
+        await db.close()
+
+
+@pytest.mark.parametrize(
+    "downloader_class",
+    [VideoDownloader, VideoDownloaderExperimental],
+    ids=["standard", "experimental"],
+)
+def test_ignoring_an_already_recorded_event_is_not_an_error(downloader_class):
+    """The second ignore should do nothing, rather than abandoning the event."""
+    assert asyncio.run(ignore_twice(downloader_class)) == [EVENT_ID]

--- a/unifi_protect_backup/downloader_experimental.py
+++ b/unifi_protect_backup/downloader_experimental.py
@@ -7,6 +7,8 @@ import shutil
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
+from sqlite3 import IntegrityError
+
 import aiosqlite
 import pytz
 from aiohttp.client_exceptions import ClientPayloadError
@@ -208,11 +210,14 @@ class VideoDownloaderExperimental:
 
     async def _ignore_event(self, event):
         self.logger.warning("Ignoring event")
-        await self._db.execute(
-            "INSERT INTO events VALUES "
-            f"('{event.id}', '{event.type.value}', '{event.camera_id}',"
-            f"'{event.start.timestamp()}', '{event.end.timestamp()}')"
-        )
+        try:
+            await self._db.execute(
+                "INSERT INTO events VALUES "
+                f"('{event.id}', '{event.type.value}', '{event.camera_id}',"
+                f"'{event.start.timestamp()}', '{event.end.timestamp()}')"
+            )
+        except IntegrityError:
+            self.logger.debug(f"Event {event.id} already exists in database, skipping")
         await self._db.commit()
 
     async def _check_video_length(self, video, duration):


### PR DESCRIPTION
With `EXPERIMENTAL_DOWNLOADER` set, ignoring an event that is already in the database logs `Unexpected exception occurred, abandoning event` with a `UNIQUE constraint failed: events.id` traceback underneath it, which doesn't say much about what actually went wrong.

The insert in `_ignore_event` is unguarded:

```python
async def _ignore_event(self, event):
    self.logger.warning("Ignoring event")
    await self._db.execute(
        "INSERT INTO events VALUES "
        f"('{event.id}', '{event.type.value}', '{event.camera_id}',"
        f"'{event.start.timestamp()}', '{event.end.timestamp()}')"
    )
    await self._db.commit()
```

f150687 added an `except IntegrityError` around the same insert in `downloader.py`, `uploader.py` and `missing_event_checker.py`, but not here. Of the four `INSERT INTO events` in the package this is the only one left that can still throw. `downloader_experimental.py` started as a copy of `downloader.py` and nothing in either file refers to the other, so fixes to the original don't reach it.

That commit describes the case it covers as the same event arriving from both the websocket and the missing event checker, which applies here the same way. The event is already recorded, then it turns out to be invalid or fails ten times, and the insert in `_ignore_event` raises straight past the `continue` into the handler at the bottom of the loop.

This copies the same try/except across, so `_ignore_event` is now identical in both files. The test ignores one event twice and checks both downloader classes end up with one row instead of an exception.

I kept the test synchronous, driving the coroutine with `asyncio.run()`, so it doesn't need pytest-asyncio. #254 does add that dependency, and writing this one the same way would have meant either adding it twice or this only being mergeable after that one.

The other overlap with #254 is that on current main this exception also skips the `continue`, so `current_event` is left pointing at the event, which is the thing that PR fixes. They don't touch the same lines and I've checked they merge cleanly together, so either order works and neither depends on the other.
