### PR TITLE
Ask the database only for the current chunk's event IDs

### DIFF
--- a/tests/test_missing_event_checker.py
+++ b/tests/test_missing_event_checker.py
@@ -1,0 +1,130 @@
+"""Tests for the missing event checker's lookup of already-backed-up event IDs."""
+
+import asyncio
+
+import pytest
+from datetime import datetime, timedelta, timezone
+
+from dateutil.relativedelta import relativedelta
+from uiprotect.data.nvr import Event
+from uiprotect.data.types import EventType
+
+from unifi_protect_backup.missing_event_checker import SQL_MAX_VARIABLES, MissingEventChecker
+from unifi_protect_backup.unifi_protect_backup_core import create_database
+from unifi_protect_backup.utils import VideoQueue
+
+CAMERA = "67cb31f301131a03e401cf0e"
+BASE = datetime(2026, 9, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def make_event(n: int) -> Event:
+    """Build a completed motion event."""
+    return Event.model_construct(
+        id=f"event-{n:04d}",
+        type=EventType.MOTION,
+        camera_id=CAMERA,
+        start=BASE + timedelta(seconds=n),
+        end=BASE + timedelta(seconds=n + 10),
+        smart_detect_types=[],
+    )
+
+
+class _Protect:
+    """Stub Protect API that serves one chunk, then reports exhaustion."""
+
+    def __init__(self, events):
+        """Init."""
+        self._events = events
+        self.calls = 0
+        self.connect_event = asyncio.Event()
+        self.connect_event.set()
+
+    async def get_events(self, **kwargs):
+        """Return the chunk once, then report exhaustion."""
+        self.calls += 1
+        return self._events if self.calls == 1 else []
+
+
+class _Downloader:
+    def __init__(self):
+        """Init."""
+        self.download_queue = asyncio.Queue()
+        self.upload_queue = VideoQueue(1024)
+        self.current_event = None
+
+
+def make_checker(db, events):
+    """Build a checker wired to stub Protect and downloader objects."""
+    return MissingEventChecker(
+        protect=_Protect(events),
+        db=db,
+        download_queue=asyncio.Queue(),
+        downloader=_Downloader(),
+        uploaders=[],
+        retention=relativedelta(days=7),
+        detection_types={"motion"},
+        ignore_cameras=set(),
+        cameras=set(),
+    )
+
+
+async def record(db, event):
+    """Write an event straight into the events table, as a completed backup would."""
+    await db.execute(
+        "INSERT INTO events VALUES "
+        f"('{event.id}', '{event.type.value}', '{event.camera_id}',"
+        f"'{event.start.timestamp()}', '{event.end.timestamp()}')"
+    )
+
+
+@pytest.fixture
+async def db():
+    """Build an in-memory database using the real production schema."""
+    connection = await create_database(":memory:")
+    yield connection
+    await connection.close()
+
+
+async def collect(checker):
+    """Drain the checker's generator into a list of event IDs."""
+    return [event.id async for event in checker._get_missing_events()]
+
+
+async def test_events_already_backed_up_are_excluded(db):
+    """Events already recorded must not be offered for re-download."""
+    events = [make_event(n) for n in range(5)]
+    await record(db, events[1])
+    await record(db, events[3])
+    await db.commit()
+
+    assert await collect(make_checker(db, events)) == ["event-0000", "event-0002", "event-0004"]
+
+
+async def test_nothing_backed_up_yields_everything(db):
+    """With an empty database every event is missing."""
+    events = [make_event(n) for n in range(5)]
+    assert len(await collect(make_checker(db, events))) == 5
+
+
+async def test_lookup_batches_without_dropping_ids(db):
+    """More events than fit in one statement's bound parameters."""
+    count = SQL_MAX_VARIABLES * 2 + 37
+    events = [make_event(n) for n in range(count)]
+    for event in events:
+        await record(db, event)
+    await db.commit()
+
+    assert await collect(make_checker(db, events)) == []
+
+
+async def test_batching_finds_the_one_missing_event_past_the_boundary(db):
+    """The gap must still be found when it sits in a later batch."""
+    count = SQL_MAX_VARIABLES * 2
+    events = [make_event(n) for n in range(count)]
+    missing = events[SQL_MAX_VARIABLES + 5]
+    for event in events:
+        if event is not missing:
+            await record(db, event)
+    await db.commit()
+
+    assert await collect(make_checker(db, events)) == [missing.id]

--- a/unifi_protect_backup/missing_event_checker.py
+++ b/unifi_protect_backup/missing_event_checker.py
@@ -18,6 +18,9 @@ from unifi_protect_backup.utils import EVENT_TYPES_MAP, wanted_event_type
 
 logger = logging.getLogger(__name__)
 
+# Batch size for `IN (...)` lookups, under SQLite's lowest bound-parameter limit.
+SQL_MAX_VARIABLES = 400
+
 
 class MissingEventChecker:
     """Periodically checks if any unifi protect events exist within the retention period that are not backed up."""
@@ -88,12 +91,16 @@ class MissingEventChecker:
             # Next chunks start time should be the start of the oldest complete event in the current chunk
             start_time = max([event.start for event in unifi_events.values() if event.end is not None])
 
-            # Get list of events that have been backed up from the database
-
-            # events(id, type, camera_id, start, end)
-            async with self._db.execute("SELECT * FROM events") as cursor:
-                rows = await cursor.fetchall()
-                db_event_ids = {row[0] for row in rows}
+            # Only this chunk's IDs are tested against `existing_ids` below, so ask the
+            # database for those rather than reading the whole table.
+            db_event_ids: Set[str] = set()
+            chunk_ids = list(unifi_events)
+            for i in range(0, len(chunk_ids), SQL_MAX_VARIABLES):
+                batch = chunk_ids[i : i + SQL_MAX_VARIABLES]
+                # Only `?` placeholders are interpolated here; the IDs are bound.
+                placeholders = ",".join("?" * len(batch))
+                async with self._db.execute(f"SELECT id FROM events WHERE id IN ({placeholders})", batch) as cursor:
+                    db_event_ids.update(row[0] for row in await cursor.fetchall())
 
             # Prevent re-adding events currently in the download/upload queue
             downloading_event_ids = {event.id for event in self._downloader.download_queue._queue}  # type: ignore


### PR DESCRIPTION
The missing event checker reads the whole events table on every pass:

```python
async with self._db.execute("SELECT * FROM events") as cursor:
    rows = await cursor.fetchall()
    db_event_ids = {row[0] for row in rows}
```

and then only ever uses it to test the ids in the chunk it just fetched from Protect:

```python
existing_ids = db_event_ids | downloading_event_ids | uploading_event_ids
missing_events = {
    event_id: event for event_id, event in unifi_events.items() if event_id not in existing_ids
}
```

My events.sqlite has 1.35M rows in it. Reading the whole thing measures ~3.5s and a 541MB peak, once per chunk, once per interval. Most of that time is in aiosqlite's worker thread rather than on the event loop, so the memory is the part that matters. It lands next to a download buffer that defaults to 512MiB, which is a lot to be holding at once on a Pi.

Asking for the chunk's own ids gives the same set, and measures 0.4ms and a 74KB peak on the same database:

```
SELECT id FROM events WHERE id IN (?, ?, ...)
```

The ids get passed in as parameters instead of being built into the SQL string. A 500 event chunk fits in one statement on any SQLite build, so the batching is only there so that stays true if `chunk_size` is ever raised. Happy to drop it if you'd rather keep it simple.

Behaviour is unchanged, so the tests cover the batching instead: that no id gets dropped at a batch boundary, and that a missing event past the boundary is still found.

I left a comment on #225 about this a couple of days ago. This is narrower than what that PR is doing and independent of it, so close this if it gets in the way.
